### PR TITLE
Add gorm plugin for encrypted fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module conjur-in-go
 go 1.14
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.0
+	github.com/stretchr/testify v1.7.0 // indirect
 	gorm.io/driver/postgres v1.0.8
 	gorm.io/gorm v1.21.8
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -35,6 +37,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -209,6 +212,7 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -259,6 +263,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -416,6 +422,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.0.8 h1:PAgM+PaHOSAeroTjHkCHCBIHHoBIf9RgPWGo8dF2DA8=
 gorm.io/driver/postgres v1.0.8/go.mod h1:4eOzrI1MUfm6ObJU/UcmbXyiHSs8jSwH95G5P5dxcAg=
 gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=

--- a/pkg/model/secret.go
+++ b/pkg/model/secret.go
@@ -1,12 +1,8 @@
 package model
 
-import (
-	"database/sql"
-)
-
 type Secret struct {
-	ResourceId string
-	Value      sql.RawBytes
+	ResourceId string `silo:"aad"`
+	Value      string `silo:"encrypted"`
 }
 
 func (s Secret) TableName() string {

--- a/pkg/server/endpoints/get-secret.go
+++ b/pkg/server/endpoints/get-secret.go
@@ -82,13 +82,8 @@ func RegisterSecretReadEndpoint(server *server.Server) {
 				http.Error(writer, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			secretValue, err := keystore.Cipher().Decrypt([]byte(secret.ResourceId), secret.Value)
-			if err != nil {
-				http.Error(writer, err.Error(), http.StatusInternalServerError)
-				return
-			}
 
-			writer.Write(secretValue)
+			writer.Write([]byte(secret.Value))
 		},
 	).Methods("GET")
 }

--- a/pkg/slosilo/store/model.go
+++ b/pkg/slosilo/store/model.go
@@ -1,13 +1,9 @@
 package store
 
-import (
-	"database/sql"
-)
-
 type StoredKey struct {
-	Id          string
+	Id          string `silo:"aad"`
 	Fingerprint string
-	Key         sql.RawBytes
+	Key         string `silo:"encrypted"`
 }
 
 func (_ StoredKey) TableName() string {

--- a/pkg/slosilo/store/silo-plugin.go
+++ b/pkg/slosilo/store/silo-plugin.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"conjur-in-go/pkg/slosilo"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type options struct {
+	// The key to use for encrypt/decrypt operations
+	keystore *KeyStore
+}
+
+// ApplyOption applies a give set of supplied options
+type ApplyOption func(o *options)
+
+type processor func(string, string) string
+
+type siloPlugin struct {
+	opt *options
+}
+
+// WithKeyStore applies the supplied key to the options for use in
+// encryption/decryption
+func WithKeyStore(keystore *KeyStore) ApplyOption {
+	return func(o *options) {
+		o.keystore = keystore
+	}
+}
+
+func defaultOptions() *options {
+	return new(options)
+}
+
+// New constructs a new plugin based silo.  It encrypts all secure labeled fields
+// before write and decrypts after read.
+func NewPlugin(opts ...ApplyOption) gorm.Plugin {
+	dst := defaultOptions()
+
+	for _, apply := range opts {
+		apply(dst)
+	}
+
+	return siloPlugin{
+		opt: dst,
+	}
+}
+
+func (s siloPlugin) Name() string {
+	return "silo"
+}
+
+func (s siloPlugin) encrypt(content string, additionalData string) string {
+	nonce, err := slosilo.RandomNonce()
+	if err != nil {
+		panic(err)
+	}
+
+	result, err := s.opt.keystore.Cipher().Encrypt([]byte(additionalData), []byte(content), nonce)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(result)
+}
+
+func (s siloPlugin) decrypt(content string, additionalData string) string {
+	result, err := s.opt.keystore.Cipher().Decrypt([]byte(additionalData), []byte(content))
+	if err != nil {
+		panic(err)
+	}
+	return string(result)
+}
+
+func (s siloPlugin) Initialize(db *gorm.DB) (err error) {
+	db.Callback().Create().Before("gorm:create").Register("silo:before_create", s.encryptQuery)
+	db.Callback().Create().After("gorm:create").Register("silo:after_create", s.decryptQuery)
+	db.Callback().Update().Before("gorm:update").Register("silo:before_update", s.encryptQuery)
+	db.Callback().Query().After("gorm:query").Register("silo:after_query", s.decryptQuery)
+
+	return
+}
+
+func (s siloPlugin) encryptQuery(db *gorm.DB) {
+	s.processQuery(db, s.encrypt)
+}
+
+func (s siloPlugin) decryptQuery(db *gorm.DB) {
+	s.processQuery(db, s.decrypt)
+}
+
+func (s siloPlugin) processQuery(db *gorm.DB, fn processor) {
+	if db.Statement.Schema != nil {
+		switch db.Statement.ReflectValue.Kind() {
+		case reflect.Struct:
+			var destMap map[string]interface{}
+			if dest, ok := db.Statement.Dest.(map[string]interface{}); ok {
+				destMap = dest
+			}
+			s.processFields(db, db.Statement.ReflectValue, destMap, fn)
+		case reflect.Slice, reflect.Array:
+			var destMapList []map[string]interface{}
+			if dest, ok := db.Statement.Dest.([]map[string]interface{}); ok {
+				destMapList = dest
+			}
+			for i := 0; i < db.Statement.ReflectValue.Len(); i++ {
+				var destMap map[string]interface{}
+				if i < len(destMapList) {
+					destMap = destMapList[i]
+				}
+				s.processFields(db, db.Statement.ReflectValue.Index(i), destMap, fn)
+			}
+		}
+	}
+}
+
+// decryptFields replaces the value on a returned record with the decrypted value
+func (s siloPlugin) processFields(db *gorm.DB, reflectValue reflect.Value, dataDestination map[string]interface{}, fn processor) {
+	aad := getAdditionalData(db, reflectValue)
+	for _, field := range db.Statement.Schema.Fields {
+		if field.Tag.Get("silo") == "encrypted" {
+			if fieldValue, isZero := field.ValueOf(reflectValue); !isZero {
+				switch field.FieldType.Kind() {
+				case reflect.String:
+					// decrypted, err := s.opt.symmetric.Decrypt([]byte(aad), []byte(fieldValue.(string)))
+					result := fn(fieldValue.(string), aad)
+					field.Set(reflectValue, result)
+					if _, ok := dataDestination[field.Name]; ok {
+						dataDestination[field.Name] = result
+					}
+				default:
+					fmt.Printf("Unsupported encrypted field datatype: %+v\n", field)
+				}
+			}
+		}
+	}
+}
+
+// getAdditionalAdata assembles the string to use as additional data when encrypting/decrypting
+// data based on schema field tags
+func getAdditionalData(db *gorm.DB, reflectValue reflect.Value) (result string) {
+	var aadStrings []string
+	for _, field := range db.Statement.Schema.Fields {
+		if field.Tag.Get("silo") == "aad" {
+			if fieldValue, isZero := field.ValueOf(reflectValue); !isZero {
+				kind := field.FieldType.Kind()
+				switch kind {
+				case reflect.String:
+					aadStrings = append(aadStrings, fieldValue.(string))
+				default:
+					fmt.Printf("Unsupported additional data field datatype: %+v\n", field)
+				}
+			}
+		}
+	}
+	// Sort the strings so they have a stable order
+	sort.Strings(aadStrings)
+	result = strings.Join(aadStrings, "")
+	return
+}

--- a/pkg/slosilo/store/silo-plugin_test.go
+++ b/pkg/slosilo/store/silo-plugin_test.go
@@ -1,0 +1,349 @@
+package store
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/base64"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type Suite struct {
+	suite.Suite
+	DB   *gorm.DB
+	mock sqlmock.Sqlmock
+}
+
+func (s *Suite) SetupSuite() {
+	var (
+		db  *sql.DB
+		err error
+	)
+
+	db, s.mock, err = sqlmock.New()
+	require.NoError(s.T(), err)
+
+	s.DB, err = gorm.Open(postgres.New(postgres.Config{Conn: db}), &gorm.Config{})
+	require.NoError(s.T(), err)
+	dataKey, err := base64.StdEncoding.DecodeString("6QrDHLBWYXieY5FM5DlRWRXX/wA8hefCuwMciHQ5ms0=")
+	require.NoError(s.T(), err)
+	_, err = NewKeyStore(s.DB, []byte(dataKey))
+	require.NoError(s.T(), err)
+}
+
+// AfterTest comment
+func (s *Suite) AfterTest(_, _ string) {
+	require.NoError(s.T(), s.mock.ExpectationsWereMet())
+}
+
+func TestSiloDBPlugin(t *testing.T) {
+	suite.Run(t, new(Suite))
+}
+
+type TestEncryption struct {
+	ID           uint64 `json:"id" gorm:"primary_key"`
+	Content      string `silo:"encrypted"`
+	AnotherField string `silo:"aad"`
+}
+
+type TestNoEncryption struct {
+	ID           uint64 `json:"id" gorm:"primary_key"`
+	Content      string
+	AnotherField string
+}
+
+// Used to verify that the database query does not contain the content
+// that should be encrypted
+// There isn't really a good way to verify that the field is indeed encrypted,
+// though
+type negativeMatchArgument struct{}
+
+func (n negativeMatchArgument) Match(s driver.Value) bool {
+	return !strings.HasPrefix(s.(string), "encrypted Content")
+}
+
+func (s *Suite) TestReadUnencryptedData() {
+	unencryptedRecord := TestNoEncryption{}
+	var readRecords []TestNoEncryption
+	unencryptedResult := TestNoEncryption{
+		ID:           1,
+		Content:      "unencrypted Content",
+		AnotherField: "unencrypted AnotherField",
+	}
+	// First unencrypted
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_no_encryptions" ORDER BY "test_no_encryptions"."id" LIMIT 1`)).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id", "content", "another_field"}).
+			AddRow(1, "unencrypted Content", "unencrypted AnotherField"))
+	// Last unencrypted
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_no_encryptions" ORDER BY "test_no_encryptions"."id" DESC LIMIT 1`)).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id", "content", "another_field"}).
+			AddRow(2, "unencrypted Content", "unencrypted AnotherField"))
+	// Take unencrypted
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_no_encryptions" LIMIT 1`)).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id", "content", "another_field"}).
+			AddRow(3, "unencrypted Content", "unencrypted AnotherField"))
+	// Find unencrypted
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_no_encryptions"`)).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "content", "another_field"}).
+				AddRow(4, "unencrypted Content", "unencrypted AnotherField"))
+	s.DB.First(&unencryptedRecord)
+	assert.Equal(s.T(), unencryptedRecord, unencryptedResult)
+	unencryptedRecord = TestNoEncryption{}
+	unencryptedResult.ID = 2
+	s.DB.Last(&unencryptedRecord)
+	assert.Equal(s.T(), unencryptedRecord, unencryptedResult)
+	unencryptedRecord = TestNoEncryption{}
+	unencryptedResult.ID = 3
+	s.DB.Take(&unencryptedRecord)
+	assert.Equal(s.T(), unencryptedRecord, unencryptedResult)
+	unencryptedResult.ID = 4
+	s.DB.Find(&readRecords)
+	assert.Equal(s.T(), len(readRecords), 1)
+	assert.Equal(s.T(), readRecords[0], unencryptedResult)
+}
+
+func (s *Suite) TestReadEncryptedData() {
+	encryptedContent := s.DB.Plugins["silo"].(siloPlugin).encrypt("encrypted Content", "unencrypted AnotherField")
+
+	encryptedRecord := TestEncryption{}
+	var readRecords []TestEncryption
+	encryptedResult := TestEncryption{
+		ID:           1,
+		Content:      "encrypted Content",
+		AnotherField: "unencrypted AnotherField",
+	}
+
+	// Find encrypted
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_encryptions" ORDER BY "test_encryptions"."id" LIMIT 1`)).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id", "content", "another_field"}).
+			AddRow(1, encryptedContent, "unencrypted AnotherField"))
+	// Last unencrypted
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_encryptions" ORDER BY "test_encryptions"."id" DESC LIMIT 1`)).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id", "content", "another_field"}).
+			AddRow(2, encryptedContent, "unencrypted AnotherField"))
+	// Take unencrypted
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_encryptions" LIMIT 1`)).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"id", "content", "another_field"}).
+			AddRow(3, encryptedContent, "unencrypted AnotherField"))
+	// Find unencrypted
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_encryptions"`)).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "content", "another_field"}).
+				AddRow(4, encryptedContent, "unencrypted AnotherField"))
+
+	s.DB.First(&encryptedRecord)
+	assert.Equal(s.T(), encryptedRecord, encryptedResult)
+	encryptedRecord = TestEncryption{}
+	encryptedResult.ID = 2
+	s.DB.Last(&encryptedRecord)
+	assert.Equal(s.T(), encryptedRecord, encryptedResult)
+	encryptedRecord = TestEncryption{}
+	encryptedResult.ID = 3
+	s.DB.Take(&encryptedRecord)
+	assert.Equal(s.T(), encryptedRecord, encryptedResult)
+	encryptedRecord = TestEncryption{}
+	encryptedResult.ID = 4
+	s.DB.Find(&readRecords)
+	assert.Equal(s.T(), len(readRecords), 1)
+	assert.Equal(s.T(), readRecords[0], encryptedResult)
+}
+
+func (s *Suite) TestWriteUnencryptedData() {
+	record := TestNoEncryption{
+		Content:      "non-encrypted Content",
+		AnotherField: "non-encrypted AnotherField",
+	}
+
+	resultRecord := TestNoEncryption{
+		ID:           1,
+		Content:      "non-encrypted Content",
+		AnotherField: "non-encrypted AnotherField",
+	}
+
+	batchRecords := []TestNoEncryption{
+		{Content: "batch Content 2", AnotherField: "batch AnotherField 2"},
+		{Content: "batch Content 3", AnotherField: "batch AnotherField 3"},
+	}
+
+	resultBatchRecords := []TestNoEncryption{
+		{ID: 2, Content: "batch Content 2", AnotherField: "batch AnotherField 2"},
+		{ID: 3, Content: "batch Content 3", AnotherField: "batch AnotherField 3"},
+	}
+
+	s.mock.ExpectBegin()
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`INSERT INTO "test_no_encryptions" ("content","another_field") VALUES ($1,$2) RETURNING "id"`)).
+		WithArgs("non-encrypted Content", "non-encrypted AnotherField").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	s.mock.ExpectCommit()
+
+	s.mock.ExpectBegin()
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`INSERT INTO "test_no_encryptions" ("content","another_field") VALUES ($1,$2),($3,$4) RETURNING "id"`)).
+		WithArgs("batch Content 2", "batch AnotherField 2", "batch Content 3", "batch AnotherField 3").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(2).AddRow(3))
+	s.mock.ExpectCommit()
+
+	s.DB.Create(&record)
+	assert.Equal(s.T(), record, resultRecord)
+
+	s.DB.Create(&batchRecords)
+	assert.Equal(s.T(), batchRecords, resultBatchRecords)
+}
+
+func (s *Suite) TestWriteEncryptedData() {
+	record := TestEncryption{
+		Content:      "encrypted Content",
+		AnotherField: "non-encrypted AnotherField",
+	}
+
+	// TODO: Update to expected decrypted (original) value
+	resultRecord := TestEncryption{
+		ID:           1,
+		Content:      "encrypted Content",
+		AnotherField: "non-encrypted AnotherField",
+	}
+
+	batchRecords := []TestEncryption{
+		{Content: "encrypted Content 2", AnotherField: "non-encrypted AnotherField 2"},
+		{Content: "encrypted Content 3", AnotherField: "non-encrypted AnotherField 3"},
+	}
+
+	// TODO: Update to expected decrypted (original) values
+	resultBatchRecords := []TestEncryption{
+		{ID: 2, Content: "encrypted Content 2", AnotherField: "non-encrypted AnotherField 2"},
+		{ID: 3, Content: "encrypted Content 3", AnotherField: "non-encrypted AnotherField 3"},
+	}
+
+	// TODO: Update to expected encrypted value
+	s.mock.ExpectBegin()
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`INSERT INTO "test_encryptions" ("content","another_field") VALUES ($1,$2) RETURNING "id"`)).
+		WithArgs(negativeMatchArgument{}, "non-encrypted AnotherField").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	s.mock.ExpectCommit()
+
+	// TODO: Update to expected encrypted values
+	s.mock.ExpectBegin()
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`INSERT INTO "test_encryptions" ("content","another_field") VALUES ($1,$2),($3,$4) RETURNING "id"`)).
+		WithArgs(negativeMatchArgument{}, "non-encrypted AnotherField 2", negativeMatchArgument{}, "non-encrypted AnotherField 3").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(2).AddRow(3))
+	s.mock.ExpectCommit()
+
+	s.DB.Create(&record)
+	assert.Equal(s.T(), record, resultRecord)
+
+	s.DB.Create(&batchRecords)
+	assert.Equal(s.T(), batchRecords, resultBatchRecords)
+}
+
+func (s *Suite) TestUpdateUnencrypted() {
+	var record TestNoEncryption
+
+	// Base Record
+	s.mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT * FROM "test_no_encryptions" ORDER BY "test_no_encryptions"."id" LIMIT 1`)).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "content", "another_field"}).
+				AddRow(1, "non-encrypted Content", "non-encrypted AnotherField"))
+	// Save
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec(regexp.QuoteMeta(
+		`UPDATE "test_no_encryptions" SET "content"=$1,"another_field"=$2 WHERE "id" = $3`)).
+		WithArgs("second non-encrypted Content", "non-encrypted AnotherField", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.mock.ExpectCommit()
+	// Update single column
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec(regexp.QuoteMeta(
+		`UPDATE "test_no_encryptions" SET "another_field"=$1 WHERE "id" = $2`)).
+		WithArgs("second non-encrypted AnotherField", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.mock.ExpectCommit()
+	// Update multiple columns
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec(regexp.QuoteMeta(
+		`UPDATE "test_no_encryptions" SET "content"=$1,"another_field"=$2 WHERE "id" = $3`)).
+		WithArgs("content", "anotherField", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.mock.ExpectCommit()
+
+	s.DB.First(&record)
+	record.Content = "second non-encrypted Content"
+	result := s.DB.Save(&record)
+	assert.Equal(s.T(), result.RowsAffected, int64(1))
+	assert.Nil(s.T(), result.Error)
+	result = s.DB.Model(&record).Update("another_field", "second non-encrypted AnotherField")
+	assert.Equal(s.T(), result.RowsAffected, int64(1))
+	assert.Nil(s.T(), result.Error)
+	result = s.DB.Model(&record).Updates(TestNoEncryption{Content: "content", AnotherField: "anotherField"})
+	assert.Equal(s.T(), result.RowsAffected, int64(1))
+	assert.Nil(s.T(), result.Error)
+}
+
+func (s *Suite) TestUpdateEncrypted() {
+	record := TestEncryption{
+		ID:           1,
+		Content:      "encrypted Content",
+		AnotherField: "non-encrypted AnotherField",
+	}
+
+	// Save
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec(regexp.QuoteMeta(
+		`UPDATE "test_encryptions" SET "content"=$1,"another_field"=$2 WHERE "id" = $3`)).
+		WithArgs(negativeMatchArgument{}, "non-encrypted AnotherField", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.mock.ExpectCommit()
+	// Update single column
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec(regexp.QuoteMeta(
+		`UPDATE "test_encryptions" SET "content"=$1 WHERE "id" = $2`)).
+		WithArgs(negativeMatchArgument{}, 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.mock.ExpectCommit()
+	// Update multiple columns
+	s.mock.ExpectBegin()
+	s.mock.ExpectExec(regexp.QuoteMeta(
+		`UPDATE "test_encryptions" SET "content"=$1,"another_field"=$2 WHERE "id" = $3`)).
+		WithArgs(negativeMatchArgument{}, "anotherField", 1).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.mock.ExpectCommit()
+
+	record.Content = "encrypted Content 2"
+	result := s.DB.Save(&record)
+	assert.Equal(s.T(), result.RowsAffected, int64(1))
+	assert.Nil(s.T(), result.Error)
+	result = s.DB.Model(&record).Update("Content", "encrypted Content 3")
+	assert.Equal(s.T(), result.RowsAffected, int64(1))
+	assert.Nil(s.T(), result.Error)
+	result = s.DB.Model(&record).Updates(TestEncryption{Content: "content 4", AnotherField: "anotherField"})
+	assert.Equal(s.T(), result.RowsAffected, int64(1))
+	assert.Nil(s.T(), result.Error)
+}
+
+// assert.Panics(s.T(), func() {functionThatPanics(arg)}, "The code did not panic")


### PR DESCRIPTION
This adds a gorm plugin that will automatically encrypt/decrypt
fields if they have `silo:"encrypted"` tags, using the `silo:"aad"`
tags as additional data.  If encryption/decryption fails, the plugin
will panic so that further processing for writing/returning data
does not occur to prevent accidental writing of encrypted data.

The plugin is added to the db object and initialized within
keystore so it is fully transparent to the rest of the application.